### PR TITLE
Fix wrong npm scripts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ npm run build
 # build for production and view the bundle analyzer report
 npm run build --report
 
-# run unit tests
-npm run unit
+# run linter
+npm run lint
 
-# run e2e tests
-npm run e2e
+# run linter and if possible fix automatically
+npm run fix
 
 # run all tests
 npm test


### PR DESCRIPTION
There are no `e2e` or `unit` commands in package.json, thus these lines should be replaced with commands that acutally exist there.